### PR TITLE
Create and delete progress post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,11 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.11.tgz",
       "integrity": "sha512-WyMXDxk/WZ+f2lOCeEvDWUce2f5Kk2sNfvArK8f+PlUnzFdy/MBzLXrmbMgyZXP7GP4ooUxYV8Sdmoh1hGk1Uw=="
     },
+    "@posva/vuefire-core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@posva/vuefire-core/-/vuefire-core-1.0.2.tgz",
+      "integrity": "sha512-cgCklRR/Cg1nOzVFcOibp7w2ng0BYccpBTdKnR46t9oGQvQX6D+Jtd25F3icx2gznOBvcckvtD3HQAkE52r1nA=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -4596,15 +4601,6 @@
           "dev": true,
           "optional": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4613,6 +4609,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5176,13 +5181,6 @@
           "version": "3.0.2",
           "bundled": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5190,6 +5188,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -10875,15 +10880,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10892,6 +10888,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -11636,6 +11641,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
+    },
+    "vuefire": {
+      "version": "2.0.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/vuefire/-/vuefire-2.0.0-alpha.15.tgz",
+      "integrity": "sha512-xP9VWz5FdhpoIHLwTEZ1H34nrbDuWATuHc8dE+STZfKeU+J2f1AfefFUQrBp7/Pmd25SCMcDb+Oz3TOyQ9lWBQ==",
+      "requires": {
+        "@posva/vuefire-core": "1.0.2"
+      }
     },
     "vuetify": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "firebase": "^5.5.4",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",
+    "vuefire": "^2.0.0-alpha.15",
     "vuetify": "^1.0.0",
     "vuex": "^3.0.1"
   },

--- a/src/components/PostProgressPicItem.vue
+++ b/src/components/PostProgressPicItem.vue
@@ -1,19 +1,46 @@
 <template>
-  <v-form v-model="valid">
+  <v-form>
     <v-text-field
-      v-model="name"
-      :rules="nameRules"
-      :counter="10"
-      label="Name"
+      v-model.trim="photoDescription"
+      label="Description"
       required
     ></v-text-field>
+    <v-btn
+      @click="postProgressItem"
+    >
+      Post
+    </v-btn>
   </v-form>
 </template>
 
 <script>
 
+import { fsdb } from '../main.js'
+import firebase from 'firebase'
+
 export default {
-  name: 'post-progress-pic-item'
+  name: 'post-progress-pic-item',
+  data () {
+    return {
+      progressPicItems: [],
+      photoDescription: ''
+    }
+  },
+  firestore: {
+    progressPicItems: fsdb.collection('progress pic item')
+  },
+  methods: {
+    postProgressItem: function () {
+      if (this.photoDescription) {
+        this.$firestoreRefs.progressPicItems.add({
+          description: this.photoDescription,
+          created: firebase.firestore.FieldValue.serverTimestamp(),
+          user: this.$store.state.user.email
+        })
+        this.photoDescription = ''
+      }
+    }
+  }
 }
 </script>
 

--- a/src/components/ProgressPicItem.vue
+++ b/src/components/ProgressPicItem.vue
@@ -10,12 +10,12 @@
         <v-card-title primary-title>
           <div>
             <h3 class="headline mb-0">Kangaroo Valley Safari</h3>
-            <div>Located two hours south of Sydney in the <br>Southern Highlands of New South Wales, ...</div>
+            <div>{{ item }}</div>
           </div>
         </v-card-title>
 
         <v-card-actions>
-          <v-btn flat color="orange">Share</v-btn>
+          <v-btn flat color="red" @click="deleteItem">Delete</v-btn>
           <v-btn flat color="orange">Explore</v-btn>
         </v-card-actions>
       </v-card>
@@ -24,9 +24,19 @@
 </template>
 
 <script>
+import { fsdb } from '../main.js'
 
 export default {
-  name: 'progress-pic-item'
+  name: 'progress-pic-item',
+  props: ['item'],
+  firestore: {
+    progressPicItems: fsdb.collection('progress pic item')
+  },
+  methods: {
+    deleteItem: function () {
+      this.$firestoreRefs.progressPicItems.doc(this.item.id).delete()
+    }
+  }
 }
 </script>
 

--- a/src/components/ProgressPicItem.vue
+++ b/src/components/ProgressPicItem.vue
@@ -3,20 +3,21 @@
     <v-flex xs12 sm6 offset-sm3>
       <v-card>
         <v-img
-          src="https://cdn.vuetifyjs.com/images/cards/desert.jpg"
-          aspect-ratio="2.75"
+          :src="imageUrl"
         ></v-img>
-
         <v-card-title primary-title>
           <div>
-            <h3 class="headline mb-0">Kangaroo Valley Safari</h3>
+            <h3 class="headline mb-0">
+              {{ item.description }}
+              <br> posted by {{ item.user }}
+              <br> at {{ photoDate }}
+            </h3>
             <div>{{ item }}</div>
           </div>
         </v-card-title>
 
         <v-card-actions>
           <v-btn flat color="red" @click="deleteItem">Delete</v-btn>
-          <v-btn flat color="orange">Explore</v-btn>
         </v-card-actions>
       </v-card>
     </v-flex>
@@ -24,17 +25,56 @@
 </template>
 
 <script>
-import { fsdb } from '../main.js'
+import { fsdb, storage } from '../main.js'
 
 export default {
   name: 'progress-pic-item',
   props: ['item'],
+  data () {
+    return {
+      imageUrl: ''
+    }
+  },
+  mounted: function () {
+    this.getImageUrl()
+  },
   firestore: {
     progressPicItems: fsdb.collection('progress pic item')
   },
+  computed: {
+    photoDate: function () {
+      if (this.item.created) {
+        return new Date(this.item.created.seconds * 1000).toString()
+      }
+    }
+  },
   methods: {
     deleteItem: function () {
-      this.$firestoreRefs.progressPicItems.doc(this.item.id).delete()
+      storage.ref().child(this.item.fileLocation).delete()
+      .then(() => {
+        this.$firestoreRefs.progressPicItems.doc(this.item.id).delete()
+        .catch(function (error) {
+          var errorMsg = 'Error deleting item from database'
+          console.log(errorMsg, error)
+        })
+      })
+      .catch(function (error) {
+        var errorMsg = 'Error deleting image file from storage'
+        console.log(errorMsg, error)
+      })
+    },
+    getImageUrl: function () {
+      storage.ref().child(this.item.fileLocation).getDownloadURL()
+      .then(url => {
+        // we could use axios or jquery instead
+        var xhr = new XMLHttpRequest()
+        xhr.open('GET', url)
+        this.imageUrl = url
+      })
+      .catch(function (error) {
+        var errorMsg = 'Error downloading image'
+        console.log(errorMsg, error)
+      })
     }
   }
 }

--- a/src/components/ProgressPicItem.vue
+++ b/src/components/ProgressPicItem.vue
@@ -39,7 +39,7 @@ export default {
     this.getImageUrl()
   },
   firestore: {
-    progressPicItems: fsdb.collection('progress pic item')
+    progressPicItems: fsdb.collection('progress-post')
   },
   computed: {
     photoDate: function () {
@@ -48,33 +48,35 @@ export default {
       }
     }
   },
+  watch: {
+    item: function (newData, oldData) {
+      this.getImageUrl()
+    }
+  },
   methods: {
     deleteItem: function () {
       storage.ref().child(this.item.fileLocation).delete()
-      .then(() => {
-        this.$firestoreRefs.progressPicItems.doc(this.item.id).delete()
-        .catch(function (error) {
-          var errorMsg = 'Error deleting item from database'
-          console.log(errorMsg, error)
-        })
-      })
-      .catch(function (error) {
+      .catch(error => {
         var errorMsg = 'Error deleting image file from storage'
+        console.log(errorMsg, error)
+      })
+      this.$firestoreRefs.progressPicItems.doc(this.item.id).delete()
+      .catch(error => {
+        var errorMsg = 'Error deleting item from database'
         console.log(errorMsg, error)
       })
     },
     getImageUrl: function () {
-      storage.ref().child(this.item.fileLocation).getDownloadURL()
-      .then(url => {
-        // we could use axios or jquery instead
-        var xhr = new XMLHttpRequest()
-        xhr.open('GET', url)
-        this.imageUrl = url
-      })
-      .catch(function (error) {
-        var errorMsg = 'Error downloading image'
-        console.log(errorMsg, error)
-      })
+      if (this.item.fileLocation) {
+        storage.ref().child(this.item.fileLocation).getDownloadURL()
+        .then(url => {
+          this.imageUrl = url
+        })
+        .catch(error => {
+          var errorMsg = 'Error downloading image'
+          console.log(errorMsg, error)
+        })
+      }
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -46,3 +46,4 @@ let firestore = app.firestore()
 firestore.settings(firestoreSettings)
 
 export const fsdb = firestore
+export const storage = app.storage()

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,12 @@ import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
 import { store } from './store'
 import firebase from 'firebase'
+import VueFire from 'vuefire'
 
 Vue.use(Vuetify)
-firebase.initializeApp({
+Vue.use(VueFire)
+
+let app = firebase.initializeApp({
   apiKey: 'AIzaSyDKeLsWxRS_tg5zzkD1qlw-ot5Jl_MZFyE',
   authDomain: 'swolemates-276ca.firebaseapp.com',
   databaseURL: 'https://swolemates-276ca.firebaseio.com',
@@ -34,3 +37,12 @@ const unsubscribe = firebase.auth()
   })
   unsubscribe()
 })
+
+// silence the console warnings
+const firestoreSettings = {
+  timestampsInSnapshots: true
+}
+let firestore = app.firestore()
+firestore.settings(firestoreSettings)
+
+export const fsdb = firestore

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -40,7 +40,7 @@ export default {
     }
   },
   firestore: {
-    progressPicItems: fsdb.collection('progress pic item')
+    progressPicItems: fsdb.collection('progress-post')
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -13,8 +13,9 @@
         </post-progress-pic-item>
         
         <progress-pic-item 
-          v-for='n in 4'
-          :key='n'
+          v-for='item in progressPicItems'
+          :key='item.id'
+          :item="item"
         >
         </progress-pic-item>
       </v-flex>
@@ -24,6 +25,7 @@
 
 <script>
 
+import { fsdb } from '../main.js'
 import ProgressPicItem from '../components/ProgressPicItem.vue'
 import PostProgressPicItem from '../components/PostProgressPicItem.vue'
 
@@ -31,6 +33,14 @@ export default {
   components: {
     ProgressPicItem,
     PostProgressPicItem
+  },
+  data () {
+    return {
+      progressPicItems: []
+    }
+  },
+  firestore: {
+    progressPicItems: fsdb.collection('progress pic item')
   }
 }
 </script>


### PR DESCRIPTION
Users can create a Progress Pic Item (progress post, or whatever to call it), and it will be stored in Firestore. The post includes a description and an image file. 

The home page is hooked to the Firestore so it retrieves the post and then we get the image file from storage. 

What's missing: 
* clear file from uploader after upload (should be done as apart of the html scaffold/ui tasks)
* the create and delete buttons need to disable themselves to prevent additional clicks (also should be done as html scaffold/ui tasks)